### PR TITLE
update volume out calc

### DIFF
--- a/ref-exchange/src/simple_pool.rs
+++ b/ref-exchange/src/simple_pool.rs
@@ -255,7 +255,7 @@ impl SimplePool {
 
         // Update volumes.
         self.volumes[in_idx].input.0 += amount_in;
-        self.volumes[in_idx].output.0 += amount_out;
+        self.volumes[out_idx].output.0 += amount_out;
 
         amount_out
     }


### PR DESCRIPTION
Isn't this supposed to update the `out_idx` volume instead?