### PR TITLE
storage_withdraw needs to be payable

### DIFF
--- a/ref-exchange/src/storage_impl.rs
+++ b/ref-exchange/src/storage_impl.rs
@@ -39,6 +39,7 @@ impl StorageManagement for Contract {
             .unwrap()
     }
 
+    #[payable]
     fn storage_withdraw(&mut self, amount: Option<U128>) -> StorageBalance {
         assert_one_yocto();
         let account_id = env::predecessor_account_id();


### PR DESCRIPTION
I think this method needs to be payable because of the `assert_one_yocto`