### PR TITLE
Proposal: require subsequent amount_in in swap actions to be nil.

### DIFF
--- a/ref-exchange/src/action.rs
+++ b/ref-exchange/src/action.rs
@@ -11,7 +11,7 @@ pub struct SwapAction {
     pub token_in: AccountId,
     /// Amount to exchange.
     /// If amount_in is None, it will take amount_out from previous step.
-    /// Will fail if amount_in is None on the first step.
+    /// Must be `None` in the first step and `Some(.)` in any other step. Will panic otherwise.
     pub amount_in: Option<U128>,
     /// Token to swap into.
     pub token_out: AccountId,

--- a/ref-exchange/src/simple_pool.rs
+++ b/ref-exchange/src/simple_pool.rs
@@ -316,7 +316,7 @@ mod tests {
             accounts(2).as_ref(),
             1,
             accounts(3).as_ref(),
-            Some(accounts(4).as_ref().clone()),
+            &Some(accounts(4).as_ref().clone()),
         );
         assert_eq!(
             pool.share_balances(accounts(0).as_ref()),
@@ -348,7 +348,7 @@ mod tests {
             accounts(2).as_ref(),
             1,
             accounts(3).as_ref(),
-            Some(accounts(4).as_ref().clone()),
+            &Some(accounts(4).as_ref().clone()),
         );
         assert_eq!(
             pool.share_balances(accounts(0).as_ref()),


### PR DESCRIPTION
### Proposal 

Currently we only require that the first swap action `amount_in` is set. In the subsequent actions, however, it's more intuitive to always use the output of the previous action.