### PR TITLE
Allow function access key to trade if all tokens are whitelisted

### DIFF
--- a/ref-exchange/src/account_deposit.rs
+++ b/ref-exchange/src/account_deposit.rs
@@ -93,6 +93,7 @@ impl Contract {
     /// Registers given token in the user's account deposit.
     /// Fails if not enough balance on this account to cover storage.
     pub fn register_tokens(&mut self, token_ids: Vec<ValidAccountId>) {
+        assert_one_yocto();
         let sender_id = env::predecessor_account_id();
         let mut deposits = self.get_account_deposits(&sender_id);
         deposits.register(&token_ids);
@@ -102,6 +103,7 @@ impl Contract {
     /// Unregister given token from user's account deposit.
     /// Panics if the balance of any given token is non 0.
     pub fn unregister_tokens(&mut self, token_ids: Vec<ValidAccountId>) {
+        assert_one_yocto();
         let sender_id = env::predecessor_account_id();
         let mut deposits = self.get_account_deposits(&sender_id);
         for token_id in token_ids {

--- a/ref-exchange/src/errors.rs
+++ b/ref-exchange/src/errors.rs
@@ -14,6 +14,7 @@ pub const ERR22_NOT_ENOUGH_TOKENS: &str = "E22: not enough tokens in deposit";
 pub const ERR24_NON_ZERO_TOKEN_BALANCE: &str = "E24: non-zero token balance";
 pub const ERR25_CALLBACK_POST_WITHDRAW_INVALID: &str =
     "E25: expected 1 promise result from withdraw";
+pub const ERR26_ACCESS_KEY_NOT_ALLOWED: &str = "E26: access key not allowed";
 
 // Liquidity operations //
 

--- a/ref-exchange/src/owner.rs
+++ b/ref-exchange/src/owner.rs
@@ -25,9 +25,11 @@ impl Contract {
     }
 
     /// Remove whitelisted token. Only can be called by owner.
-    pub fn remove_whitelisted_token(&mut self, token: ValidAccountId) {
+    pub fn remove_whitelisted_tokens(&mut self, tokens: Vec<ValidAccountId>) {
         self.assert_owner();
-        self.whitelisted_tokens.remove(token.as_ref());
+        for token in tokens {
+            self.whitelisted_tokens.remove(token.as_ref());
+        }
     }
 
     /// Migration function from v2 to v2.


### PR DESCRIPTION
Two changes:
 - register / unregister tokens for the user requires a 1 yN deposit to prevent access keys whitelisted tokens.
 - `swap` function supports 0 attached deposit, but all tokens must be already registered or globally whitelisted.

Note: this still allows potential issues with trading over pools that have 100% of fee as smart contract allows to trade on any pool that has whitelisted tokens.

Is this still an issue? Should there be a list of whitelisted pools for access key? Or alternatively can just add a limit on the fee that access key can trade with?