### PR TITLE
feat: remove blockchain interface usage and fix compile bug

### DIFF
--- a/test-token/src/lib.rs
+++ b/test-token/src/lib.rs
@@ -6,6 +6,10 @@ use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::json_types::{ValidAccountId, U128};
 use near_sdk::{near_bindgen, AccountId, PanicOnDefault, PromiseOrValue};
 
+
+#[cfg(target_arch = "wasm32")]
+use near_sdk::env;
+
 near_sdk::setup_alloc!();
 
 #[near_bindgen]


### PR DESCRIPTION
- No need to use `BLOCKCHAIN_INTERFACE` since it's just in wasm32 context, calls host functions directly
- Fixes compilation of test-token in wasm32 arch (some macro is using `env` implicitly, so I will look into that unrelated to this)