### PR TITLE
makefile for build/test/release + simple ci for pr/pushes to master

### DIFF
--- a/.github/workflows/exchange.yaml
+++ b/.github/workflows/exchange.yaml
@@ -1,9 +1,9 @@
 name: Test ref-exchange 
 on: 
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 jobs:
   test_ref_exchange:
     runs-on: ubuntu-latest 

--- a/.github/workflows/exchange.yaml
+++ b/.github/workflows/exchange.yaml
@@ -1,0 +1,23 @@
+name: Test ref-exchange 
+on: [push]
+  #  push:
+  #    branches: [ master ]
+  #  pull_request:
+  #    branches: [ master ]
+jobs:
+  test_ref_exchange:
+    runs-on: ubuntu-latest 
+    container:
+      image: nearprotocol/contract-builder:latest
+      env:
+        RUSTFLAGS: -C link-arg=-s
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          rustup toolchain install stable-2021-11-01 && \
+          rustup default stable-2021-11-01 && \
+          rustup target add wasm32-unknown-unknown && \
+          cargo build --target wasm32-unknown-unknown --release
+      - run: |
+          cd ref-exchange && \
+          cargo test

--- a/.github/workflows/exchange.yaml
+++ b/.github/workflows/exchange.yaml
@@ -1,9 +1,9 @@
 name: Test ref-exchange 
-on: [push]
-  #  push:
-  #    branches: [ master ]
-  #  pull_request:
-  #    branches: [ master ]
+on: 
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 jobs:
   test_ref_exchange:
     runs-on: ubuntu-latest 

--- a/.github/workflows/farming.yaml
+++ b/.github/workflows/farming.yaml
@@ -1,9 +1,9 @@
 name: Test ref-farming
-on: [push]
-  #  push:
-  #    branches: [ master ]
-  #  pull_request:
-  #    branches: [ master ]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 jobs:
   test_ref_farming:
     runs-on: ubuntu-latest 

--- a/.github/workflows/farming.yaml
+++ b/.github/workflows/farming.yaml
@@ -19,5 +19,6 @@ jobs:
           rustup target add wasm32-unknown-unknown && \
           cargo build --target wasm32-unknown-unknown --release
       - run: |
-          cd ref-exchange && \
+          cd ref-farming && \
+          ./build_local.sh && \
           cargo test

--- a/.github/workflows/farming.yaml
+++ b/.github/workflows/farming.yaml
@@ -1,0 +1,23 @@
+name: Test ref-farming
+on: [push]
+  #  push:
+  #    branches: [ master ]
+  #  pull_request:
+  #    branches: [ master ]
+jobs:
+  test_ref_farming:
+    runs-on: ubuntu-latest 
+    container:
+      image: nearprotocol/contract-builder:latest
+      env:
+        RUSTFLAGS: -C link-arg=-s
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          rustup toolchain install stable-2020-10-08 && \
+          rustup default stable-2020-10-08 && \
+          rustup target add wasm32-unknown-unknown && \
+          cargo build --target wasm32-unknown-unknown --release
+      - run: |
+          cd ref-exchange && \
+          cargo test

--- a/.github/workflows/farming.yaml
+++ b/.github/workflows/farming.yaml
@@ -1,9 +1,9 @@
 name: Test ref-farming
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 jobs:
   test_ref_farming:
     runs-on: ubuntu-latest 

--- a/.github/workflows/farming.yaml
+++ b/.github/workflows/farming.yaml
@@ -14,8 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
-          rustup toolchain install stable-2020-10-08 && \
-          rustup default stable-2020-10-08 && \
+          rustup toolchain install stable-2021-11-01 && \
+          rustup default stable-2021-11-01 && \
           rustup target add wasm32-unknown-unknown && \
           cargo build --target wasm32-unknown-unknown --release
       - run: |

--- a/Makefile
+++ b/Makefile
@@ -41,14 +41,14 @@ remove-builders:
 
 define create_builder 
 	docker ps -a | grep $(1) || docker create \
-     --mount type=bind,source=${PWD},target=/host \
-     --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
-     --name=$(1) \
-     -w /host/$(2) \
-     -e RUSTFLAGS='-C link-arg=-s' \
-     -it \
-     ${NEAR_CONTRACT_BUILDER_IMAGE} \
-     /bin/bash
+		--mount type=bind,source=${PWD},target=/host \
+		--cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
+		--name=$(1) \
+		-w /host/$(2) \
+		-e RUSTFLAGS='-C link-arg=-s' \
+		-it \
+		${NEAR_CONTRACT_BUILDER_IMAGE} \
+		/bin/bash
 endef
 
 define start_builder

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,69 @@
+NEAR_BUILDER_IMAGE=nearprotocol/contract-builder
+
+FARMING_DIR=ref-farming
+FARMING_BUILDER_NAME=build_ref_farming
+FARMING_RUSTUP_SETUP="rustup toolchain install stable-2020-10-08;rustup default stable-2020-10-08;rustup target add wasm32-unknown-unknown; cargo build --target wasm32-unknown-unknown --release"
+FARMING_RELEASE=ref_farming
+
+EXCHANGE_DIR=ref-exchange
+EXCHANGE_BUILDER_NAME=build_ref_exchange
+EXCHANGE_RUSTUP_SETUP="rustup toolchain install stable-2021-11-01; rustup default stable-2021-11-01; rustup target add wasm32-unknown-unknown; cargo build --target wasm32-unknown-unknown --release"
+EXCHANGE_RELEASE=ref_exchange
+
+define create_builder 
+	docker ps -a | grep $(1) || docker create \
+     --mount type=bind,source=${PWD},target=/host \
+     --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
+     --name=$(1) \
+     -w /host/$(2) \
+     -e RUSTFLAGS='-C link-arg=-s' \
+     -it \
+     ${NEAR_BUILDER_IMAGE} \
+     /bin/bash
+endef
+
+define start_builder
+	docker ps | grep $(1) || docker start $(1) 
+endef
+
+define setup_builder
+	docker exec $(1) /bin/bash -c $(2)
+endef
+
+define remove_builder
+	docker stop $(1) && docker rm $(1) 
+endef
+
+define release_wasm
+	cp ${PWD}/target/wasm32-unknown-unknown/release/$(1).wasm ${PWD}/res/$(1)_release.wasm
+endef
+
+res:
+	mkdir -p res
+
+build-farming:
+	$(call create_builder,${FARMING_BUILDER_NAME},${FARMING_DIR} )
+	$(call start_builder,${FARMING_BUILDER_NAME}) 
+	$(call setup_builder,${FARMING_BUILDER_NAME},${FARMING_RUSTUP_SETUP}) 
+	
+test-farming: build-farming
+	docker exec ${FARMING_BUILDER_NAME} cargo test 
+
+release-farming: res
+	$(call release_wasm,${FARMING_RELEASE})
+
+
+build-exchange:
+	$(call create_builder,${EXCHANGE_BUILDER_NAME},${EXCHANGE_DIR} )
+	$(call start_builder,${EXCHANGE_BUILDER_NAME}) 
+	$(call setup_builder,${EXCHANGE_BUILDER_NAME},${EXCHANGE_RUSTUP_SETUP}) 
+	
+test-exchange: build-exchange
+	docker exec ${EXCHANGE_BUILDER_NAME} cargo test 
+
+release-exchange: res
+	$(call release_wasm,${EXCHANGE_RELEASE})
+
+remove-builders:
+	$(call remove_builder,${FARMING_BUILDER_NAME})
+	$(call remove_builder,${EXCHANGE_BUILDER_NAME})

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ define setup_builder
 endef
 
 define remove_builder
-	docker stop $(1) && docker rm $(1) 
+	docker stop $(1) && sleep 3 && docker rm $(1) 
 endef
 
 define release_wasm

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ build-farming:
 	$(call create_builder,${FARMING_BUILDER_NAME},${FARMING_DIR})
 	$(call start_builder,${FARMING_BUILDER_NAME})
 	$(call setup_builder,${FARMING_BUILDER_NAME})
+	docker exec ${FARMING_BUILDER_NAME} /bin/bash build_local.sh
 	
 test-farming: build-farming
 	docker exec ${FARMING_BUILDER_NAME} cargo test 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ EXCHANGE_DIR=ref-exchange
 EXCHANGE_BUILDER_NAME=build_ref_exchange
 EXCHANGE_RELEASE=ref_exchange
 
+test-all: test-exchange test-farming
+
 build-farming:
 	$(call create_builder,${FARMING_BUILDER_NAME},${FARMING_DIR})
 	$(call start_builder,${FARMING_BUILDER_NAME})

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,41 @@
-NEAR_BUILDER_IMAGE=nearprotocol/contract-builder
+NEAR_CONTRACT_BUILDER_IMAGE=nearprotocol/contract-builder
 
 FARMING_DIR=ref-farming
 FARMING_BUILDER_NAME=build_ref_farming
-FARMING_RUSTUP_SETUP="rustup toolchain install stable-2020-10-08;rustup default stable-2020-10-08;rustup target add wasm32-unknown-unknown; cargo build --target wasm32-unknown-unknown --release"
 FARMING_RELEASE=ref_farming
 
 EXCHANGE_DIR=ref-exchange
 EXCHANGE_BUILDER_NAME=build_ref_exchange
-EXCHANGE_RUSTUP_SETUP="rustup toolchain install stable-2021-11-01; rustup default stable-2021-11-01; rustup target add wasm32-unknown-unknown; cargo build --target wasm32-unknown-unknown --release"
 EXCHANGE_RELEASE=ref_exchange
+
+build-farming:
+	$(call create_builder,${FARMING_BUILDER_NAME},${FARMING_DIR})
+	$(call start_builder,${FARMING_BUILDER_NAME})
+	$(call setup_builder,${FARMING_BUILDER_NAME})
+	
+test-farming: build-farming
+	docker exec ${FARMING_BUILDER_NAME} cargo test 
+
+build-exchange:
+	$(call create_builder,${EXCHANGE_BUILDER_NAME},${EXCHANGE_DIR})
+	$(call start_builder,${EXCHANGE_BUILDER_NAME})
+	$(call setup_builder,${EXCHANGE_BUILDER_NAME})
+	
+test-exchange: build-exchange
+	docker exec ${EXCHANGE_BUILDER_NAME} cargo test 
+
+res:
+	mkdir -p res
+
+release-farming: res
+	$(call release_wasm,${FARMING_RELEASE})
+
+release-exchange: res
+	$(call release_wasm,${EXCHANGE_RELEASE})
+
+remove-builders:
+	$(call remove_builder,${FARMING_BUILDER_NAME}) || \
+	$(call remove_builder,${EXCHANGE_BUILDER_NAME})
 
 define create_builder 
 	docker ps -a | grep $(1) || docker create \
@@ -18,7 +45,7 @@ define create_builder
      -w /host/$(2) \
      -e RUSTFLAGS='-C link-arg=-s' \
      -it \
-     ${NEAR_BUILDER_IMAGE} \
+     ${NEAR_CONTRACT_BUILDER_IMAGE} \
      /bin/bash
 endef
 
@@ -27,7 +54,7 @@ define start_builder
 endef
 
 define setup_builder
-	docker exec $(1) /bin/bash -c $(2)
+	docker exec $(1) /bin/bash rust_setup.sh 
 endef
 
 define remove_builder
@@ -37,33 +64,3 @@ endef
 define release_wasm
 	cp ${PWD}/target/wasm32-unknown-unknown/release/$(1).wasm ${PWD}/res/$(1)_release.wasm
 endef
-
-res:
-	mkdir -p res
-
-build-farming:
-	$(call create_builder,${FARMING_BUILDER_NAME},${FARMING_DIR} )
-	$(call start_builder,${FARMING_BUILDER_NAME}) 
-	$(call setup_builder,${FARMING_BUILDER_NAME},${FARMING_RUSTUP_SETUP}) 
-	
-test-farming: build-farming
-	docker exec ${FARMING_BUILDER_NAME} cargo test 
-
-release-farming: res
-	$(call release_wasm,${FARMING_RELEASE})
-
-
-build-exchange:
-	$(call create_builder,${EXCHANGE_BUILDER_NAME},${EXCHANGE_DIR} )
-	$(call start_builder,${EXCHANGE_BUILDER_NAME}) 
-	$(call setup_builder,${EXCHANGE_BUILDER_NAME},${EXCHANGE_RUSTUP_SETUP}) 
-	
-test-exchange: build-exchange
-	docker exec ${EXCHANGE_BUILDER_NAME} cargo test 
-
-release-exchange: res
-	$(call release_wasm,${EXCHANGE_RELEASE})
-
-remove-builders:
-	$(call remove_builder,${FARMING_BUILDER_NAME})
-	$(call remove_builder,${EXCHANGE_BUILDER_NAME})

--- a/ref-exchange/rust_setup.sh
+++ b/ref-exchange/rust_setup.sh
@@ -1,0 +1,6 @@
+#/bin/bash
+VER=2021-11-01
+rustup toolchain install stable-$VER
+rustup default stable-$VER
+rustup target add wasm32-unknown-unknown
+cargo build --target wasm32-unknown-unknown --release

--- a/ref-farming/rust_setup.sh
+++ b/ref-farming/rust_setup.sh
@@ -1,5 +1,5 @@
 #/bin/bash
-VER=2020-10-08
+VER=2021-11-01
 rustup toolchain install stable-$VER
 rustup default stable-$VER
 rustup target add wasm32-unknown-unknown

--- a/ref-farming/rust_setup.sh
+++ b/ref-farming/rust_setup.sh
@@ -1,0 +1,6 @@
+#/bin/bash
+VER=2020-10-08
+rustup toolchain install stable-$VER
+rustup default stable-$VER
+rustup target add wasm32-unknown-unknown
+cargo build --target wasm32-unknown-unknown --release


### PR DESCRIPTION
- spread `build_docker.sh` logic into makefile targets
- basic ci testing for `ref-farming` and `ref-exchange` (equivalent of running `cargo test` in each) 

successful ci tests evidence: 
https://github.com/fuzzylemma/ref-contracts/actions