### PR TITLE
Add return values to add_liquidity/remove_liquidity

### DIFF
--- a/ref-exchange/src/lib.rs
+++ b/ref-exchange/src/lib.rs
@@ -205,7 +205,7 @@ impl Contract {
         pool_id: u64,
         amounts: Vec<U128>,
         min_amounts: Option<Vec<U128>>,
-    ) {
+    ) -> U128 {
         self.assert_contract_running();
         assert!(
             env::attached_deposit() > 0,
@@ -216,7 +216,7 @@ impl Contract {
         let mut amounts: Vec<u128> = amounts.into_iter().map(|amount| amount.into()).collect();
         let mut pool = self.pools.get(pool_id).expect("ERR_NO_POOL");
         // Add amounts given to liquidity first. It will return the balanced amounts.
-        pool.add_liquidity(
+        let shares = pool.add_liquidity(
             &sender_id,
             &mut amounts,
         );
@@ -235,6 +235,8 @@ impl Contract {
         self.internal_save_account(&sender_id, deposits);
         self.pools.replace(pool_id, &pool);
         self.internal_check_storage(prev_storage);
+
+        U128(shares)
     }
 
     /// For stable swap pool, user can add liquidity with token's combination as his will.
@@ -280,7 +282,7 @@ impl Contract {
 
     /// Remove liquidity from the pool into general pool of liquidity.
     #[payable]
-    pub fn remove_liquidity(&mut self, pool_id: u64, shares: U128, min_amounts: Vec<U128>) {
+    pub fn remove_liquidity(&mut self, pool_id: u64, shares: U128, min_amounts: Vec<U128>) -> Vec<U128> {
         assert_one_yocto();
         self.assert_contract_running();
         let prev_storage = env::storage_usage();
@@ -306,6 +308,11 @@ impl Contract {
                 (prev_storage - env::storage_usage()) as Balance * env::storage_byte_cost();
         }
         self.internal_save_account(&sender_id, deposits);
+
+        amounts
+            .into_iter()
+            .map(|amount| amount.into())
+            .collect()
     }
 
     /// For stable swap pool, LP can use it to remove liquidity with given token amount and distribution.


### PR DESCRIPTION
Now `add_liquidity` returns sum of minted shares and `remove_liquidity` returns vector with tokens amounts. This change is necessary for cross-contract interaction in particular in the [PembRock Finance](https://github.com/PembROCK-Finance) project